### PR TITLE
Hotlink darts image, because wget not available everywhere.

### DIFF
--- a/_episodes/03-basic-workflow.md
+++ b/_episodes/03-basic-workflow.md
@@ -45,10 +45,7 @@ fall within the unit circle.
 >
 > 3. Add an image to explain the concept:
 > ```
-> !wget https://coderefinery.github.io/jupyter/img/darts.svg
-> ```
-> ```
-> ![Darts](darts.svg)
+> ![Darts](https://coderefinery.github.io/jupyter/img/darts.svg)
 > ```
 >
 > 4. Import `random` module:


### PR DESCRIPTION
- wget isn't available on windows/mac by default.  #31.
- Instead of different instructions for different OSs, why not
  hotlink?  This isn't so good for reproducibility but makes lesson
  flow simpler.  I'm not saying it *should* be this way but making
  this for discussion.
- We'd have to make a point of saying that hotlinking means the image
  could go away anytime...