### PR TITLE
rename "exercises" to "examples"

### DIFF
--- a/_episodes/05-examples.md
+++ b/_episodes/05-examples.md
@@ -1,10 +1,10 @@
 ---
 layout: episode
-title: Exercises
+title: Examples
 teaching: 0
 exercises: 30
 questions:
- - Mixed exercises to practice various aspects of using Jupyter
+ - Mixed examples/exercises to practice various aspects of using Jupyter
 objectives:
  - Learn more advanced usage of widgets.
  - Learn how to profile code and install a new line-profiler tool.


### PR DESCRIPTION
Because these can typically not be done during a lesson.
I find this name now clearer not only for learners but also
for instructors who might want to give interactive widgets
as an exercise to the whole classroom.

This is part of #67.