### PR TITLE
_episodes/06-sharing: Fix link to (now renamed) 05-examples

### DIFF
--- a/_episodes/06-sharing.md
+++ b/_episodes/06-sharing.md
@@ -77,7 +77,7 @@ faster access to cloud resources:
 
 > ## (Optional) Exercise: share an interactive (ipywidgets) notebook via [Binder](https://mybinder.org)
 >
-> - Take the solution from <https://coderefinery.github.io/jupyter/05-exercises/#widgets-for-interactive-data-fitting>.
+> - Take the solution from <https://coderefinery.github.io/jupyter/05-examples/#widgets-for-interactive-data-fitting>.
 > - Push it to a GitHub/GitLab repository.
 > - Create a `requirements.txt` file in your notebook repository, e.g.:
 >   ```


### PR DESCRIPTION
- The previous PR changed this name to 05-examples, and I remembered
  to check right after merging.
- Review: minimal