### PR TITLE
get rid of sphinx warnings

### DIFF
--- a/content/examples.md
+++ b/content/examples.md
@@ -232,7 +232,7 @@ from the previous exercise.
 Copy-paste the code into a cell
 
 Install the line profiler
-```python
+```
 !pip install line_profiler
 ```
 Load the IPython extension
@@ -240,16 +240,16 @@ Load the IPython extension
 %load_ext line_profiler
 ```
 See help:
-```python
+```
 %lprun?
 ```
 Use the line profiler on the `walk` function:
-```python
+```
 %lprun -f walk walk(10000)
 ```
 Aha, most time is spent on the line calling the `step()` function.
 Run line profiler on `step`:
-```python
+```
 %lprun -f step walk(10000)
 ```
 
@@ -479,7 +479,7 @@ Load extension:
 %load_ext cpp_ext
 ```
 Get help on the cpp magic:
-```python
+```
 %%cpp?
 ```
 Hello World program in C++
@@ -765,7 +765,7 @@ from earlier lessons.
 
 4. Import the new zipf module, and have a look at the docstring for one
    of the functions:
-   ```python
+   ```
    import zipf
    zipf.top_n_word?
    ```

--- a/content/extra-features.md
+++ b/content/extra-features.md
@@ -16,18 +16,18 @@
 ### Access to help
 
 We can get help on an object using a question mark:
-```python
+```
 import numpy as np
 np.sum?
 ```
 
 Or two question marks to also see the source code:
-```python
+```
 np.sum??
 ```
 
 List all names in a module matching pattern:
-```python
+```
 ?np.*sum*
 ```
 
@@ -56,7 +56,7 @@ np.sum
   `Use Git and the optional Unix tools from the Windows Command Prompt`
 - Make sure your cell command doesn't require interaction
 
-```python
+```
 !echo "hello"
 ```
 
@@ -66,7 +66,7 @@ hello
 ```
 
 We can also capture the output of a shell command:
-```python
+```
 notebooks = !ls *.ipynb
 ```
 
@@ -91,7 +91,7 @@ There are two kinds of magics:
 ```
 
 Question mark shows help:
-```python
+```
 %sx?
 ```
 


### PR DESCRIPTION
it does not know how to highlight python code with "?" in it