### PR TITLE
add snippet about possible widget problems

### DIFF
--- a/content/extra-features.md
+++ b/content/extra-features.md
@@ -107,6 +107,10 @@ Widgets add more interactivity to Notebooks, allowing one to visualize and contr
 from ipywidgets import interact
 ```
 
+> The `ipywidgets` package is included in the standard 
+> CodeRefinery conda environment, but if you run into problems getting widgets to work  
+> please refer to the official [installation instructions](https://ipywidgets.readthedocs.io/en/latest/user_install.html).
+
 #### Use `interact` as a function
 ```python
 def f(x, y, s):


### PR DESCRIPTION
a number of problems with using widgets have been reported in CR workshops
through the years, but as we now only use JupyterLab and the installation
of ipywidgets now automatically configures JupyterLab to enable them, future
problems are hopefully unlikely. Corner cases are described in the ipywidgets
installation instructions which are linked in this commit.

This commit thus fixes #106, fixes #91, fixes #62 and fixes #89