### PR TITLE
140 add solutions to optional exercises in the sharing episode

### DIFF
--- a/content/first-notebook.md
+++ b/content/first-notebook.md
@@ -1,3 +1,4 @@
+
 # A first computational notebook
 
 ```{objectives}
@@ -66,9 +67,9 @@ If you prefer to select in which browser to open JupyterLab, use:
 $ jupyter-lab --no-browser
 ```
 
-(first-notebook)=
-
 ---
+
+(first-notebook)=
 
 ## An example computational notebook
 
@@ -163,9 +164,9 @@ Demonstrate out-of-order execution problems and how to avoid them:
 - Then demonstrate "run all cells"
 ```
 
-(other-kernels)=
-
 ---
+
+(other-kernels)=
 
 ## Notebooks in other languages
 

--- a/content/sharing.md
+++ b/content/sharing.md
@@ -154,6 +154,7 @@ This exercise is for those who use Rmd files instead of Jupyter notebooks.
 - [EGI Notebooks](https://notebooks.egi.eu) (see also https://egi-notebooks.readthedocs.io)
 - [JupyterLab](https://github.com/jupyterlab/jupyterlab) supports sharing and collaborative editing of notebooks via Google Drive. Recently
   it also added support for [Shared editing with collaborative notebook model](https://github.com/jupyterlab/jupyterlab/pull/10118).
+- [JupyterLite](https://jupyterlite.readthedocs.io/en/latest/) creates a Jupyterlab environment in the browser and can be hosted as a GitHub page.
 - [Notedown](https://github.com/aaren/notedown), [Jupinx](https://github.com/QuantEcon/sphinxcontrib-jupyter) and [DocOnce](https://github.com/hplgit/doconce) can take Markdown or Sphinx files and generate Jupyter Notebooks
 - [Voilà](https://voila.readthedocs.io/en/stable/) allows you to convert a Jupyter Notebook into an interactive dashboard
 - The `jupyter nbconvert` tool can convert a (`.ipynb`) notebook file to:

--- a/content/sharing.md
+++ b/content/sharing.md
@@ -57,15 +57,53 @@
 Let's look at the same [activity inequality
 repository](https://github.com/timalthoff/activityinequality).  
 
-- Start the repository [in Binder by using this
-link](https://mybinder.org/v2/gh/timalthoff/activityinequality/master). 
-- `fig3/fig3bc.ipynb` is a Python notebook, so works in Binder.
-  Most others are in R, which also works in Binder.  [But
+- Start the repository in Binder [using this link](https://mybinder.org/v2/gh/timalthoff/activityinequality/master). 
+- `fig3/fig3bc.ipynb` is a Python notebook, so it works in Binder.
+  Most others are in R, which also works in Binder. [But
   how?](https://mybinder.readthedocs.io/en/latest/howto/languages.html)
-  Try to run the notebook - can you make it work?
-- Install the missing requirements with `pip`.  Does it work now?
-  Why or why not?
-- How could this be better?
+- Try to run the notebook. What happens?
+- Most likely the run brakes down immediately in the first cell
+  ```jupyter
+  %matplotlib inline
+  import pandas as pd
+  import matplotlib.pyplot as plt
+  import seaborn as sns
+  sns.set(style="whitegrid")
+  from itertools import cycle
+  ```
+  with a long list of `ModuleNotFoundError` messages. This is 
+  because the required Python packages have not been installed and can not be imported. 
+  The missing packages include, at least, `pandas` and `matplotlib` mentioned in the 
+  error message.
+- To install the missing requirements, add a new code cell to the beginning of the
+  notebook with the contents
+  ```jupyter
+  !python3 -m pip install pandas matplotlib
+  ```  
+  and run the notebook again. What happens now?  
+- Again, the run brakes down due to missing packages. This time the culprit is the
+  `seaborn`package. Modify the first cell to also install it with
+  ```jupyter
+  !python3 -m pip install pandas matplotlib seaborn
+  ```  
+  and try to run the notebook for the third time. Does it finally work? 
+  What could have been done differently by the developer?
+- A good way to make a notebook more usable is to create a `requirements.txt` file 
+  containing the necessary packages to run the notebook and add it next to the notebook
+  in the repository.
+- In this case, the `requirements.txt` could look like this
+  ```file 
+  # requirements.txt
+  pandas
+  matplotlib
+  seaborn
+  ```
+  and to make sure the packages are installed, one could add a code cell to the beginning
+  of original notebook with the line  
+  ```jupyter
+  !python3 -m pip install -r requirements.txt
+  ```
+
 ````
 
 (share-widget)=

--- a/content/sharing.md
+++ b/content/sharing.md
@@ -55,11 +55,10 @@
 
 ````{exercise} (Optional) Exercise: what happens without requirements.txt?
 Let's look at the same [activity inequality
-repository](https://github.com/timalthoff/activityinequality).  We
-can start this repository [in Binder by using this
-link](https://mybinder.org/v2/gh/timalthoff/activityinequality/master).
+repository](https://github.com/timalthoff/activityinequality).  
 
-- Start the repository in Binder
+- Start the repository [in Binder by using this
+link](https://mybinder.org/v2/gh/timalthoff/activityinequality/master). 
 - `fig3/fig3bc.ipynb` is a Python notebook, so works in Binder.
   Most others are in R, which also works in Binder.  [But
   how?](https://mybinder.readthedocs.io/en/latest/howto/languages.html)

--- a/content/sharing.md
+++ b/content/sharing.md
@@ -82,7 +82,7 @@ repository](https://github.com/timalthoff/activityinequality).
   ```  
   and run the notebook again. What happens now?  
 - Again, the run brakes down due to missing packages. This time the culprit is the
-  `seaborn`package. Modify the first cell to also install it with
+  `seaborn` package. Modify the first cell to also install it with
   ```jupyter
   !python3 -m pip install pandas matplotlib seaborn
   ```  

--- a/content/version-control.md
+++ b/content/version-control.md
@@ -106,3 +106,6 @@ For more information please see the
 - [nbdev](https://nbdev.fast.ai/getting_started.html) developed by [fast.ai](https://www.fast.ai/)
   is a notebook-driven development platform which includes support for [git-friendly Jupyter 
   notebooks](https://nbdev.fast.ai/tutorials/git_friendly_jupyter.html)
+- [Verdant](https://github.com/mkery/Verdant/) is a JupyterLab extension that automatically
+  records history of all experiments you run in a Jupyter notebook, and stores them in an
+  `.ipyhistory` JSON file.


### PR DESCRIPTION
Note: Branch is work-in-progress, comments and modifications are welcome, not expected to be merged as is.

Fixes #140, in particular, section "(Optional) Exercise: what happens without requirements.txt?" 

Adds 
- a little narrative how to debug/fix the import errors due to missing packages
- a missing solution proposal of adding a `requirements.txt` + cell running `pip install`

Some inconveniences
- I would personally not use `pip install`in the notebook since it would be easy to accidentally make a system-wide install. However, in the context of Binder and a few minutes long exercise, this is probably fine.
- This existing bullet point 
  - "fig3/fig3bc.ipynb is a Python notebook, so it works in Binder. Most others are in R, which also works in Binder. [But how?](https://mybinder.readthedocs.io/en/latest/howto/languages.html)" feels a bit out of place but I understand why it was added in the first place (to include more R).
- `matplotlib`is not necessary in the requirements as it is a dependency of `seaborn`. However, leaving it out would require an explanation causing a potential rabbit hole.

