### PR TITLE
remove %matplotlib inline as it seems to break interactivity

### DIFF
--- a/content/extra-features.md
+++ b/content/extra-features.md
@@ -171,7 +171,6 @@ Widgets can be used to interactively explore or analyze data.
    import random
    from ipywidgets import interact, widgets
 
-   %matplotlib inline
    from matplotlib import pyplot
 
 


### PR DESCRIPTION
From a comment in the notes:

"I had trouble getting matplotlib to behave interactively with widgets when %inline is invoked. Maybe remove that? "

Additionally:
"I think matplotlib has a quick way to invoke its widget with %widget as well"

Removing the `%matplotlib inline` line seems to have fixed "reactivity" in the plot when moving the slider.